### PR TITLE
Add sections for overridable variables in config

### DIFF
--- a/src/main/java/no/digipost/dropwizard/TypeSafeConfigFactory.java
+++ b/src/main/java/no/digipost/dropwizard/TypeSafeConfigFactory.java
@@ -67,7 +67,7 @@ public class TypeSafeConfigFactory<T> extends ConfigurationFactory<T> {
             final Config configWithSecrets = secretConfig.withFallback(envConfig);
 
             final Config finalConfig = configWithSecrets.withoutPath(ENVIRONMENTS_CONFIG_KEY);
-            final ConfigObject rootConfigObject = finalConfig.resolve().root();
+            final ConfigObject rootConfigObject = finalConfig.resolve().withoutPath("variables").root();
 
             logConfig(finalConfig, rootConfigObject);
 

--- a/src/test/java/no/digipost/dropwizard/ConfigurationTest.java
+++ b/src/test/java/no/digipost/dropwizard/ConfigurationTest.java
@@ -85,6 +85,22 @@ public class ConfigurationTest {
         assertThat(config.database.getPassword(), is("secret_password"));
     }
 
+    @Test
+    public void should_interpolate_variables() throws IOException, ConfigurationException {
+        setEnv("test");
+        final TestConfig config =
+                configFactory.build(configSourceProvider, "test-config.yml");
+        assertThat(config.database.getPassword(), is("default variable value"));
+    }
+
+    @Test
+    public void should_interpolate_variables_with_overrides() throws IOException, ConfigurationException {
+        setEnv("local");
+        final TestConfig config =
+                configFactory.build(configSourceProvider, "test-config.yml");
+        assertThat(config.database.getPassword(), is("overridden variable value"));
+    }
+
     private void setEnv(final String env) {
         System.setProperty(ENV_KEY, env);
     }

--- a/src/test/resources/test-config.yml
+++ b/src/test/resources/test-config.yml
@@ -1,9 +1,15 @@
+variables:
+  testvar1: "default variable value"
+
 database:
   driverClass: org.postgresql.Driver
   user: test
+  password: ${variables.testvar1}
 
 environments:
   local:
+    variables:
+      testvar1: "overridden variable value"
     database:
       url: local_url
 


### PR DESCRIPTION
A special "variables" section can be used to define variables and override variables pr. environment. The variables section is not included in the Java config object. A variable can be refered to anywhere in the config-file with the following syntax key: ${variables.name}