### PR TITLE
Support environment specific secret config

### DIFF
--- a/src/test/java/no/digipost/dropwizard/ConfigurationTest.java
+++ b/src/test/java/no/digipost/dropwizard/ConfigurationTest.java
@@ -38,46 +38,43 @@ import static no.digipost.dropwizard.TypeSafeConfigurationFactory.SECRET_KEY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class ConfigurationTest {
+class ConfigurationTest {
 
-    final Validator validator;
-    final ObjectMapper objectMapper;
-    final ConfigurationFactory<TestConfig> configFactory;
+    private static final Validator validator = Validation.byProvider(HibernateValidator.class).configure()
+                                                  .buildValidatorFactory().getValidator();
+    private static final ObjectMapper objectMapper = Jackson.newObjectMapper();
 
-    public ConfigurationTest() {
-        validator = Validation.byProvider(HibernateValidator.class)
-                .configure()
-                .buildValidatorFactory().getValidator();
-        objectMapper = Jackson.newObjectMapper();
-        configFactory = new TypeSafeConfigurationFactory<>(TestConfig.class, validator, objectMapper, "dw");
-    }
+    private final ConfigurationFactory<TestConfig> configFactory =
+        new TypeSafeConfigurationFactory<>(TestConfig.class, validator, objectMapper, "dw");
+    private final ConfigurationSourceProvider configSourceProvider =
+        new ConfigurationSourceProviderWithFallback(new FileConfigurationSourceProvider(), new ResourceConfigurationSourceProvider());
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         System.setProperty("driverClassSystemProperty", "driverClassFromSystemProperty");
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         System.clearProperty(ENV_KEY);
         System.clearProperty(SECRET_KEY);
         System.clearProperty("driverClassSystemProperty");
     }
 
     @Test
-    public void should_load_local_config_without_errors() throws IOException, ConfigurationException {
+    void should_load_local_config_without_errors() throws IOException, ConfigurationException {
         setEnv("local");
         configFactory.build(configSourceProvider, "test-config.yml");
     }
 
     @Test
-    public void should_load_test_config_without_errors() throws IOException, ConfigurationException {
+    void should_load_test_config_without_errors() throws IOException, ConfigurationException {
         setEnv("test");
         configFactory.build(configSourceProvider, "test-config.yml");
     }
 
     @Test
-    public void should_use_default_values_when_environment_has_no_specific_value() throws IOException, ConfigurationException {
+    void should_use_default_values_when_environment_has_no_specific_value() throws IOException, ConfigurationException {
         setEnv("local");
         final TestConfig config =
                 configFactory.build(configSourceProvider, "test-config.yml");
@@ -85,7 +82,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void should_override_defaults_with_environment_specific_values() throws IOException, ConfigurationException {
+    void should_override_defaults_with_environment_specific_values() throws IOException, ConfigurationException {
         setEnv("test");
         final TestConfig config =
                 configFactory.build(configSourceProvider, "test-config.yml");
@@ -93,7 +90,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void should_allow_empty_default_with_environment_specific_value() throws IOException, ConfigurationException {
+    void should_allow_empty_default_with_environment_specific_value() throws IOException, ConfigurationException {
         setEnv("test");
         final TestConfig config =
                 configFactory.build(configSourceProvider, "test-config.yml");
@@ -101,7 +98,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void should_load_secret_config_from_file() throws IOException, ConfigurationException {
+    void should_load_secret_config_from_file() throws IOException, ConfigurationException {
         setEnv("local");
         System.setProperty(TypeSafeConfigurationFactory.SECRET_KEY, getClass().getResource("/test-secret.yml").getFile());
         final TestConfig config =
@@ -110,7 +107,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void should_interpolate_variables() throws IOException, ConfigurationException {
+    void should_interpolate_variables() throws IOException, ConfigurationException {
         setEnv("test");
         final TestConfig config =
                 configFactory.build(configSourceProvider, "test-config.yml");
@@ -118,7 +115,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void should_interpolate_variables_with_overrides() throws IOException, ConfigurationException {
+    void should_interpolate_variables_with_overrides() throws IOException, ConfigurationException {
         setEnv("local");
         final TestConfig config =
                 configFactory.build(configSourceProvider, "test-config.yml");
@@ -126,17 +123,15 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void should_resolve_system_properties() throws IOException, ConfigurationException {
+    void should_resolve_system_properties() throws IOException, ConfigurationException {
         setEnv("test2");
         final TestConfig config =
                 configFactory.build(configSourceProvider, "test-config.yml");
         assertThat(config.database.getDriverClass(), is("driverClassFromSystemProperty"));
     }
 
-    private void setEnv(final String env) {
+    private static void setEnv(final String env) {
         System.setProperty(ENV_KEY, env);
     }
 
-    private final ConfigurationSourceProvider configSourceProvider =
-            new ConfigurationSourceProviderWithFallback(new FileConfigurationSourceProvider(), new ResourceConfigurationSourceProvider());
 }

--- a/src/test/java/no/digipost/dropwizard/ConfigurationTest.java
+++ b/src/test/java/no/digipost/dropwizard/ConfigurationTest.java
@@ -107,6 +107,19 @@ class ConfigurationTest {
     }
 
     @Test
+    void supports_environment_specific_config_in_secret_config() throws IOException, ConfigurationException {
+        setEnv("test");
+        System.setProperty(TypeSafeConfigurationFactory.SECRET_KEY, getClass().getResource("/test-secret.yml").getFile());
+
+        TestConfig testEnvConfig = configFactory.build(configSourceProvider, "test-config.yml");
+        assertThat(testEnvConfig.secrets.verySecret, is("keep this to yourself!"));
+
+        setEnv("local");
+        TestConfig config = configFactory.build(configSourceProvider, "test-config.yml");
+        assertThat(config.secrets.verySecret, is("not so secret"));
+    }
+
+    @Test
     void should_interpolate_variables() throws IOException, ConfigurationException {
         setEnv("test");
 

--- a/src/test/java/no/digipost/dropwizard/ConfigurationTest.java
+++ b/src/test/java/no/digipost/dropwizard/ConfigurationTest.java
@@ -76,24 +76,24 @@ class ConfigurationTest {
     @Test
     void should_use_default_values_when_environment_has_no_specific_value() throws IOException, ConfigurationException {
         setEnv("local");
-        final TestConfig config =
-                configFactory.build(configSourceProvider, "test-config.yml");
+
+        TestConfig config = configFactory.build(configSourceProvider, "test-config.yml");
         assertThat(config.database.getDriverClass(), is("org.postgresql.Driver"));
     }
 
     @Test
     void should_override_defaults_with_environment_specific_values() throws IOException, ConfigurationException {
         setEnv("test");
-        final TestConfig config =
-                configFactory.build(configSourceProvider, "test-config.yml");
+
+        TestConfig config = configFactory.build(configSourceProvider, "test-config.yml");
         assertThat(config.database.getDriverClass(), is("overridden"));
     }
 
     @Test
     void should_allow_empty_default_with_environment_specific_value() throws IOException, ConfigurationException {
         setEnv("test");
-        final TestConfig config =
-                configFactory.build(configSourceProvider, "test-config.yml");
+
+        TestConfig config = configFactory.build(configSourceProvider, "test-config.yml");
         assertThat(config.database.getUrl(), is("test_url"));
     }
 
@@ -101,32 +101,32 @@ class ConfigurationTest {
     void should_load_secret_config_from_file() throws IOException, ConfigurationException {
         setEnv("local");
         System.setProperty(TypeSafeConfigurationFactory.SECRET_KEY, getClass().getResource("/test-secret.yml").getFile());
-        final TestConfig config =
-                configFactory.build(configSourceProvider, "test-config.yml");
+
+        TestConfig config = configFactory.build(configSourceProvider, "test-config.yml");
         assertThat(config.database.getPassword(), is("secret_password"));
     }
 
     @Test
     void should_interpolate_variables() throws IOException, ConfigurationException {
         setEnv("test");
-        final TestConfig config =
-                configFactory.build(configSourceProvider, "test-config.yml");
+
+        TestConfig config = configFactory.build(configSourceProvider, "test-config.yml");
         assertThat(config.database.getPassword(), is("default variable value"));
     }
 
     @Test
     void should_interpolate_variables_with_overrides() throws IOException, ConfigurationException {
         setEnv("local");
-        final TestConfig config =
-                configFactory.build(configSourceProvider, "test-config.yml");
+
+        TestConfig config = configFactory.build(configSourceProvider, "test-config.yml");
         assertThat(config.database.getPassword(), is("overridden variable value"));
     }
 
     @Test
     void should_resolve_system_properties() throws IOException, ConfigurationException {
         setEnv("test2");
-        final TestConfig config =
-                configFactory.build(configSourceProvider, "test-config.yml");
+
+        TestConfig config = configFactory.build(configSourceProvider, "test-config.yml");
         assertThat(config.database.getDriverClass(), is("driverClassFromSystemProperty"));
     }
 

--- a/src/test/java/no/digipost/dropwizard/TestConfig.java
+++ b/src/test/java/no/digipost/dropwizard/TestConfig.java
@@ -30,4 +30,13 @@ public class TestConfig {
 
     @JsonProperty
     public String environment;
+
+    @JsonProperty
+    public EnvironmentSpecificSecret secrets;
+}
+
+class EnvironmentSpecificSecret {
+    @JsonProperty
+    @NotNull
+    public String verySecret;
 }

--- a/src/test/resources/test-config.yml
+++ b/src/test/resources/test-config.yml
@@ -6,6 +6,9 @@ database:
   user: test
   password: ${variables.testvar1}
 
+secrets:
+  verySecret: "not so secret"
+
 environments:
   local:
     variables:

--- a/src/test/resources/test-secret.yml
+++ b/src/test/resources/test-secret.yml
@@ -1,2 +1,7 @@
 database:
   password: secret_password
+
+environments:
+  test:
+    secrets:
+      verySecret: "keep this to yourself!"


### PR DESCRIPTION
The bundle supports to construct the configuration based on two files; a "main" config file, and a separate file containing secrets. In addition, it supports a special section looking like this:
```yml
environments:
  local:
    someValue: "value for localhost"
  test:
    someValue: "value for test env"
  prod:
    someValue: "value for production"
```
This section would be "flattened" by putting one of the `someValue` at top level, based on which environment is specified. E.g. if on is running an application in `test`-environment, then `someValue: "value for test env"` will be the actual configuration.

This pull-request adds support for this environment-specific configuration also to for the configuration file containing secrets. Previously, this "flattening" was only performed for the main file.


Point-of-interests for review:
- test: `ConfigurationTest.supports_environment_specific_config_in_secret_config`
- impl: `TypeSafeConfigurationFactory` [line 83](https://github.com/digipost/typesafe-config-bundle/pull/7/files#diff-50a67df006e74e8fbaff6439d3281366R83), which performs the same operation on `secretConfig` which was previously only done on `config`. And some plumbing around to make things fit together.
- small bonus in the `TypeSafeConfigurationFactory.reduceToEnvironmentSpecific` method, [line 136](https://github.com/digipost/typesafe-config-bundle/pull/7/files#diff-50a67df006e74e8fbaff6439d3281366R136): the filter avoids exception if the `environments.env` path is not present in the config. It should not be _required_ to have an environments section for the specified environment.